### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   # exceptを使用(index, showは除きユーザーがログインしているかを確認する)
   # ログインをしていない場合は、ログインページに遷移される
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_prototype, only: [:show, :edit, :update]
 
   def index # トップ画面の表示
     @items = Item.all.order(created_at: :desc)
@@ -22,12 +23,12 @@ class ItemsController < ApplicationController
 
   def show # 詳細ページへ
     # index.html.erbからクリックされた情報をパラメータとして受け取り、show.html.erbで詳細情報を表示
-    @item = Item.find(params[:id])
+    # @item = Item.find(params[:id]) #リファクタリング
   end
 
   def edit #編集ページへ
     # new.html.erbからクリックされた情報をパラメータとして受け取り、edit.html.erbで編集ページを表示
-    @item = Item.find(params[:id])
+    # @item = Item.find(params[:id]) #リファクタリング
     # 商品出品者以外が編集画面にアクセスしようとするとトップページに遷移される
     unless current_user.id == @item.user_id
       redirect_to root_path 
@@ -36,7 +37,8 @@ class ItemsController < ApplicationController
 
   def update #更新処理
     # error_messages.html.erbでmodelオプションを使用しているため、@item(インスタンス変数)を使用する必要がある
-    @item = Item.find(params[:id])
+    # @item = Item.find(params[:id]) #リファクタリング
+    
     # 変更があった場合の処理
     if @item.update(item_params)
       #redirect_to(ルーティング→コントローラ→ビュー)、情報が更新されているのでぐるっとしているイメージ？
@@ -53,6 +55,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :explanation, :category_id, :status_id, :responsibility_id, :prefecture_id, :shipping_id,
                                  :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_prototype
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,10 @@ class ItemsController < ApplicationController
   def edit #編集ページへ
     # new.html.erbからクリックされた情報をパラメータとして受け取り、edit.html.erbで編集ページを表示
     @item = Item.find(params[:id])
+    # 商品出品者以外が編集画面にアクセスしようとするとトップページに遷移される
+    unless current_user.id == @item.user_id
+      redirect_to root_path 
+    end
   end
 
   def update #更新処理
@@ -48,4 +52,5 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :explanation, :category_id, :status_id, :responsibility_id, :prefecture_id, :shipping_id,
                                  :price, :image).merge(user_id: current_user.id)
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   # exceptを使用(index, showは除きユーザーがログインしているかを確認する)
+  # ログインをしていない場合は、ログインページに遷移される
   before_action :authenticate_user!, except: [:index, :show]
 
   def index # トップ画面の表示
@@ -34,15 +35,16 @@ class ItemsController < ApplicationController
   end
 
   def update #更新処理
-    item = Item.find(params[:id])
+    # error_messages.html.erbでmodelオプションを使用しているため、@item(インスタンス変数)を使用する必要がある
+    @item = Item.find(params[:id])
     # 変更があった場合の処理
-    if item.update(item_params)
+    if @item.update(item_params)
       #redirect_to(ルーティング→コントローラ→ビュー)、情報が更新されているのでぐるっとしているイメージ？
       redirect_to item_path
     # 変更がなかった場合の処理
     else
       #render(ビューに直接)
-      render :edit 
+      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,7 +15,7 @@ class ItemsController < ApplicationController
   def create # 保存
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to root_path 
     else
       render :new
     end
@@ -26,26 +26,24 @@ class ItemsController < ApplicationController
     # @item = Item.find(params[:id]) #リファクタリング
   end
 
-  def edit #編集ページへ
+  def edit # 編集ページへ
     # new.html.erbからクリックされた情報をパラメータとして受け取り、edit.html.erbで編集ページを表示
     # @item = Item.find(params[:id]) #リファクタリング
     # 商品出品者以外が編集画面にアクセスしようとするとトップページに遷移される
-    unless current_user.id == @item.user_id
-      redirect_to root_path 
-    end
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
-  def update #更新処理
+  def update # 更新処理
     # error_messages.html.erbでmodelオプションを使用しているため、@item(インスタンス変数)を使用する必要がある
     # @item = Item.find(params[:id]) #リファクタリング
-    
+
     # 変更があった場合の処理
     if @item.update(item_params)
-      #redirect_to(ルーティング→コントローラ→ビュー)、情報が更新されているのでぐるっとしているイメージ？
+      # redirect_to(ルーティング→コントローラ→ビュー)、情報が更新されているのでぐるっとしているイメージ？
       redirect_to item_path
     # 変更がなかった場合の処理
     else
-      #render(ビューに直接)
+      # render(ビューに直接)
       render :edit
     end
   end
@@ -60,5 +58,4 @@ class ItemsController < ApplicationController
   def set_prototype
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,17 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit #編集ページへ
+    # new.html.erbからクリックされた情報をパラメータとして受け取り、edit.html.erbで編集ページを表示
+    @item = Item.find(params[:id])
+  end
+
+  def update #更新処理
+    item = Item.find(params[:id])
+    item.update(item_params)
+    redirect_to item_path
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,8 +31,15 @@ class ItemsController < ApplicationController
 
   def update #更新処理
     item = Item.find(params[:id])
-    item.update(item_params)
-    redirect_to item_path
+    # 変更があった場合の処理
+    if item.update(item_params)
+      #redirect_to(ルーティング→コントローラ→ビュー)、情報が更新されているのでぐるっとしているイメージ？
+      redirect_to item_path
+    # 変更がなかった場合の処理
+    else
+      #render(ビューに直接)
+      render :edit 
+    end
   end
 
   private

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -142,9 +142,9 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%# item_pathでshow.html.erbに移動、編集中であっても更新されることはない %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,11 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%# 中身が入った状態で@itemが渡されている %>
+    <%= form_with model:@item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -23,7 +24,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +34,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +53,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +74,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:responsibility_id, Responsibility.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +102,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,9 +10,8 @@ app/assets/stylesheets/items/new.css %>
     <%# 中身が入った状態で@itemが渡されている %>
     <%= form_with model:@item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラー発生時のメッセージ表示%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -28,6 +27,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /商品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -139,14 +139,17 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
+    
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
       <%# item_pathでshow.html.erbに移動、編集中であっても更新されることはない %>
       <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
+    <%# /下部ボタン %>
   </div>
   <% end %>
+ 
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -24,6 +24,7 @@
       </div>
     </div>
     <%# /商品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -135,6 +136,7 @@
       </p>
     </div>
     <%# /注意書き %>
+    
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     <% if user_signed_in?%>
       <%# 出品者情報が一致している場合 %>
       <% if current_user.id == @item.user_id%>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn"%>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn"%>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy"%>
       <%# 出品者情報が一致していない場合 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users #userモデルの作成をすると自動的に反映される(rails g devise user)
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
#What
商品情報編集機能

#Why
商品情報編集機能実装のため

#提出物
ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/d4611854106ccee2a7bd192e0ea51024

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/dfd608d73712343faaad49f8e7406884

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/79e1f814b3e5a2c9bf987e3022076c03

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/9354c605471aa0c4d5820ae57278c81c

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
※補足：hoge2がhogeの出品した編集画面へ移動しようとしている
https://gyazo.com/39c057df2f06e202e543d8ed8c4c090e

ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能未実装

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
※補足：ログアウト状態でhogeの出品した編集画面へ移動しようとしている
https://gyazo.com/4182c9341b037a102686feb0b65954ef

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/81616a8890f5c8a730a530447f473c9c